### PR TITLE
fix Makefile to support SSP

### DIFF
--- a/net/ethtool/Makefile
+++ b/net/ethtool/Makefile
@@ -29,6 +29,7 @@ define Package/ethtool
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Display or change ethernet card settings
+  DEPENDS:=+SSP_SUPPORT:libssp
   URL:=http://www.kernel.org/pub/software/network/ethtool/
 endef
 


### PR DESCRIPTION
Package ethtool is missing dependencies for the following libraries:
libssp.so.0
Makefile:45: recipe for target '/home/zero/development/openwrt/bin/ar71xx/packages/packages/ethtool_3.18-1_ar71xx.ipk' failed
